### PR TITLE
Enforce video page at startup.

### DIFF
--- a/apple2dead.asm
+++ b/apple2dead.asm
@@ -40,6 +40,7 @@ romstart:
 
 
 		sta TXTSET 		; turn on text
+		sta LOWSCR		; set screen buffer starting on page 1 ($0400)
 		sta CLRALTCHAR	; turn off alt charset on later apple machines
 		sta CLR80VID	; turn off 80 col on //e or //c
 


### PR DESCRIPTION
Hi! I was helping my friend with Apple II clone bring-up using this software (thank you!).

It was however misbehaving - we could hear the beeps, so it was obvious it's running, but there was no readable output on the screen. To make things even more interesting, it was working fine (with readable output) like every ~50th restart. 

Looking at the source code I have noticed, that it sets the text mode using `sta TXTSET`, but according to the schematics, F14 register is not guaranteed to be cleared at power-up (`~CLR` input is tied to `SOFT5`). Thus the soft-switch selecting video page is not necessarily cleared. 

I've tried adding `sta LOWSCR` right after `sta TXTSET` and it indeed solved all the problems. Now it runs properly on every power-up. 
